### PR TITLE
Replaced SurveyNumber param with SurveyIDs

### DIFF
--- a/source/includes/demand/_survey-groups.md
+++ b/source/includes/demand/_survey-groups.md
@@ -422,7 +422,7 @@ POST  https://api.samplicio.us/Demand/v1/SurveyGroups/{SurveyGroupID}
 > Example Request
 
 ```shell
-curl -H "Content-Type: application/json" -H "Authorization: YOUR_API_KEY_HERE" -X POST --data '{"SurveyNumber": ["101101"]}' https://api.samplicio.us/Demand/v1/SurveyGroups/{SurveyGroupID}
+curl -H "Content-Type: application/json" -H "Authorization: YOUR_API_KEY_HERE" -X POST --data '{"SurveyIDs": ["101101"]}' https://api.samplicio.us/Demand/v1/SurveyGroups/{SurveyGroupID}
 ```
 
 ```ruby


### PR DESCRIPTION
In http://developer.lucidhq.com/#post-add-to-survey-group we had "SurveyNumber" in the example request, instead of "SurveyIDs"