### PR TITLE
Task/change dates

### DIFF
--- a/source/includes/changelog/_changelog.md
+++ b/source/includes/changelog/_changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 14 Mar 2017
+## 15 Mar 2017
 
 #### Demand API - New Properties
 

--- a/source/includes/demand/_surveys.md
+++ b/source/includes/demand/_surveys.md
@@ -3,7 +3,7 @@
 The Surveys resource allows the buyer to create new surveys, update existing surveys, and retrieve survey details in Fulcrum.
 
 #### Survey Model
-<aside class="notice">The <code class="prettyprint">CollectsPII</code> property is being introduced in stages.  Beginning March 14, 2017 the property will be included in the <code class="prettyprint">Survey</code> model, but will only accept a <code class="prettyprint">null</code> value.  On April 10, 2017, <code class="prettyprint">null</code>, <code class="prettyprint">false</code> and <code class="prettyprint">true</code> values will be accepted.  After April 24, 2017, Buyers will be required to set the property.</aside>
+<aside class="notice">The <code class="prettyprint">CollectsPII</code> property is being introduced in stages.  Beginning March 15, 2017 the property will be included in the <code class="prettyprint">Survey</code> model, but will only accept a <code class="prettyprint">null</code> value.  On April 12, 2017, <code class="prettyprint">null</code>, <code class="prettyprint">false</code> and <code class="prettyprint">true</code> values will be accepted.  After April 26, 2017, Buyers will be required to set the property.</aside>
 
 | Property                     | Type     | Description                                                                                                                                             |
 |------------------------------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
New properties deploy was pushed back a day so the dates related to the release needed to be updated.